### PR TITLE
Fix wrong app name in logger.h

### DIFF
--- a/source/logger.h
+++ b/source/logger.h
@@ -10,7 +10,7 @@
 })
 
 #define LOG_APP_TYPE "L"
-#define LOG_APP_NAME "libfunctionpatcher"
+#define LOG_APP_NAME "libnotifications"
 
 #define LOG_EX(FILENAME, FUNCTION, LINE, LOG_FUNC, LOG_LEVEL, LINE_END, FMT, ARGS...)                                                        \
     do {                                                                                                                                     \


### PR DESCRIPTION
For logging purposes (i.e. when errors are logged in this plugin), `LOG_APP_NAME` inadvertently had the same name as the library [`libfunctionpatcher`](https://github.com/wiiu-env/libfunctionpatcher). Make it `libnotifications` instead.

